### PR TITLE
Add Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ url: https://cal-itp-transit-stop.netlify.app
 
 timezone: America/Los_Angeles
 
+analytics:
+  production: UA-176840950-1
+
 collections_dir: content
 collections:
   actions:

--- a/_includes/scripts/ga.html
+++ b/_includes/scripts/ga.html
@@ -1,0 +1,15 @@
+{% if jekyll.environment == "production" %}
+  {% assign ga = site.analytics.production %}
+{% endif %}
+
+{% if ga %}
+
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ ga }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ ga }}');
+</script>
+
+{% endif %}

--- a/_includes/site/head.html
+++ b/_includes/site/head.html
@@ -12,6 +12,8 @@
   <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape}}</title>
   <meta name="description" content="{% if page.description %}{{ page.description | strip_html strip_newlines | truncate: 400 }}{% else %}{{ site.description }}{% endif %}" />
 
+  {% include scripts/ga.html %}
+
   <link href="https://fonts.googleapis.com/css?family=Proxima+Nova:400,500,700|Raleway:500,600,700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}" />
   <link rel="canonical" href="{{ page.url | absolute_url }}" />

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,8 +7,14 @@
 
 # Deploy Preview context: all deploys generated from a pull/merge request will
 # inherit these settings.
-[context.deploy-preview]
-  JEKYLL_ENV = "preview"
+[context.deploy-preview.environment]
+  JEKYLL_ENV = "deploy-preview"
+
+# Branch deploy context:
+# All deploys that are not from a pull/merge request
+# or from the production branch will inherit these settings.
+[context.branch-deploy.environment]
+  JEKYLL_ENV = "branch-deploy"
 
 [[plugins]]
   package = "./admin/plugins/ca-state-fonts"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,11 @@
 [build.environment]
   JEKYLL_ENV = "production"
 
+# Deploy Preview context: all deploys generated from a pull/merge request will
+# inherit these settings.
+[context.deploy-preview]
+  JEKYLL_ENV = "preview"
+
 [[plugins]]
   package = "./admin/plugins/ca-state-fonts"
 


### PR DESCRIPTION
@calexity this PR adds the GA code you setup (thanks!)

Jekyll has the concept of build environments, which allows us to only include the tracking code when we're building for `production`. We could setup another GA for `development` if you thought that would be useful - but at least our primary account will only show "real" traffic.

Closes #20.