### PR TITLE
Allow users to boot up docker-compose in order to access the site locally

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,7 @@ exclude:
   - docs
   - CONDUCT.md
   - LICENSE.txt
+  - docker-compose.yml
   - admin/plugins
   - _data/
   - submodules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  site:
+    image: jekyll/jekyll:4
+    command: "jekyll serve --force_polling --livereload"
+    ports:
+      - "4000:4000" # Jekyll's normal http port
+      - "35729:35729" # The development LiveReload port
+    volumes:
+      - ".:/srv/jekyll"


### PR DESCRIPTION
In a previous pull request I removed the docker-compose support to clean up the repository and now we want to add it back using the latest standards.